### PR TITLE
process global blobcollection, more io methods, minor fixes and features

### DIFF
--- a/examples/matrix.jl
+++ b/examples/matrix.jl
@@ -5,7 +5,7 @@ import Blobs: @logmsg, load, save
 using Base.Random: UUID
 import Base: serialize, deserialize, getindex, setindex!, size, append!
 
-export DenseMatBlobs, SparseMatBlobs, size, getindex, setindex!, serialize, deserialize
+export DenseMatBlobs, SparseMatBlobs, size, getindex, setindex!, serialize, deserialize, save, load
 
 const BYTES_128MB = 128 * 1024 * 1024
 
@@ -175,7 +175,7 @@ function append!{Tv,Ti}(sp::SparseMatBlobs{Tv,Ti}, S::SparseMatrixCSC{Tv,Ti})
     blob = append!(sp.coll, SparseMatrixCSC{Tv,Ti}, meta, StrongLocality(myid()), Nullable(S))
     push!(sp.splits, idxrange => blob.id)
     @logmsg("appending blob $(blob.id) of size: $(size(S)) for idxrange: $idxrange, sersz: $(meta.size)")
-    nothing
+    blob
 end
 
 function save(sp::SparseMatBlobs)
@@ -310,7 +310,7 @@ function append!{Tv,D,N}(dm::DenseMatBlobs{Tv,D,N}, M::Matrix{Tv})
     blob = append!(dm.coll, Matrix{Tv}, meta, StrongLocality(myid()), Nullable(M))
     push!(dm.splits, idxrange => blob.id)
     @logmsg("appending blob $(blob.id) of size: $(size(M)) for idxrange: $idxrange, sersz: $(meta.size)")
-    nothing
+    blob
 end
 
 DenseMatBlobs(metadir::AbstractString) = matblob(metadir)

--- a/src/Blobs.jl
+++ b/src/Blobs.jl
@@ -5,14 +5,14 @@ using Compat
 using Base.Random: UUID, uuid4
 using Base.Mmap: sync!
 using Base: IPAddr
-import Base: serialize, deserialize, append!
+import Base: serialize, deserialize, append!, flush
 
 export Locality, StrongLocality, WeakLocality
 export Mutability, Mutable, Immutable
 export Node, NodeMap, nodeids, addnode, localto, islocal
 export BlobMeta, TypedMeta, FileMeta, FunctionMeta
 export BlobIO, NoopBlobIO, FileBlobIO, FunctionBlobIO
-export Blob, BlobCollection, blobids, load, save, serialize, deserialize, register, deregister, append!
+export Blob, BlobCollection, blobids, load, save, serialize, deserialize, register, deregister, append!, flush
 
 # enable logging only during debugging
 #using Logging

--- a/src/Blobs.jl
+++ b/src/Blobs.jl
@@ -1,3 +1,5 @@
+__precompile__(true)
+
 module Blobs
 
 using Compat
@@ -14,6 +16,7 @@ export Node, NodeMap, nodeids, addnode, localto, islocal
 export BlobMeta, TypedMeta, FileMeta, FunctionMeta
 export BlobIO, NoopBlobIO, FileBlobIO, FunctionBlobIO
 export Blob, BlobCollection, blobids, load, save, serialize, deserialize, register, deregister, append!, flush, max_cached, max_cached!
+export ProcessGlobalBlob
 
 # enable logging only during debugging
 #using Logging
@@ -24,7 +27,12 @@ export Blob, BlobCollection, blobids, load, save, serialize, deserialize, regist
 #        debug($(esc(s)))
 #    end
 #end
+#macro logmsg(s)
+#end
 macro logmsg(s)
+    quote
+        info($(esc(s)))
+    end
 end
 
 
@@ -33,5 +41,12 @@ using .BlobCache
 
 include("attributes.jl")
 include("blob.jl")
+include("procglobal.jl")
+
+function __init__()
+    global const mmapped = Set{UInt}()
+    global const BLOB_REGISTRY = Dict{UUID,BlobCollection}()
+    global const DEF_NODE_MAP = initnodemap()
+end
 
 end # module

--- a/src/Blobs.jl
+++ b/src/Blobs.jl
@@ -12,7 +12,7 @@ export Mutability, Mutable, Immutable
 export Node, NodeMap, nodeids, addnode, localto, islocal
 export BlobMeta, TypedMeta, FileMeta, FunctionMeta
 export BlobIO, NoopBlobIO, FileBlobIO, FunctionBlobIO
-export Blob, BlobCollection, blobids, load, save, serialize, deserialize, register, deregister, append!, flush
+export Blob, BlobCollection, blobids, load, save, serialize, deserialize, register, deregister, append!, flush, max_cached, max_cached!
 
 # enable logging only during debugging
 #using Logging

--- a/src/Blobs.jl
+++ b/src/Blobs.jl
@@ -7,6 +7,7 @@ using Base.Mmap: sync!
 using Base: IPAddr
 import Base: serialize, deserialize, append!, flush
 
+export ismmapped, delmmapped, syncmmapped, blobmmap
 export Locality, StrongLocality, WeakLocality
 export Mutability, Mutable, Immutable
 export Node, NodeMap, nodeids, addnode, localto, islocal

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -137,8 +137,6 @@ function initnodemap(nodemap::NodeMap=NodeMap())
     nodemap
 end
 
-const DEF_NODE_MAP = initnodemap()
-
 # localto methods can be used to get a list of nodes, ips, hostnames that are local to the given entity as per the nodemap
 localto(ip::IPAddr, nodemap::NodeMap=DEF_NODE_MAP) = localto(get(nodemap.ipgroup, ip, Int[]), nodemap)
 localto(hostname::AbstractString, nodemap::NodeMap=DEF_NODE_MAP) = localto(get(nodemap.hostnamegroup, hostname, Int[]), nodemap)

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -153,7 +153,6 @@ append!(coll::UUID, blob::Blob) = append!(BlobCollection(id::UUID), blob)
 function append!(coll::BlobCollection, blob::Blob)
     (blob.data.value == nothing) || (coll.cache[blob.id] = blob.data.value)
     coll.blobs[blob.id] = blob
-    
 end
 blobids(coll::BlobCollection) = keys(coll.blobs)
 

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -139,6 +139,13 @@ function deregister(coll::BlobCollection, wrkrs::Vector{Int})
     end
 end
 
+max_cached(coll::BlobCollection) = coll.maxcache
+function max_cached!(coll::BlobCollection, maxcache::Int)
+    coll.maxcache = maxcache
+    resize!(coll.cache, maxcache)
+    nothing
+end
+
 function append!{T,L}(coll::Union{UUID,BlobCollection}, ::Type{T}, blobmeta::BlobMeta, ::Type{L}, v::Nullable{T}=Nullable{T}())
     blob = Blob(T, L, blobmeta)
     isnull(v) || (blob.data.value = get(v))

--- a/src/cache/blobcache.jl
+++ b/src/cache/blobcache.jl
@@ -101,17 +101,19 @@ function Base.resize!(lru::LRU, n::Int)
     return lru
 end
 
-function Base.delete!(lru::LRU, key)
+function Base.delete!(lru::LRU, key; callback::Bool=true)
     item = lru.ht[key]
-    lru.cb(item.k, item.v)
+    callback && lru.cb(item.k, item.v)
     delete!(lru.q, item)
     delete!(lru.ht, key)
     return lru
 end
 
-function Base.empty!(lru::LRU)
-    for item in values(lru.ht)
-        lru.cb(item.k, item.v)
+function Base.empty!(lru::LRU; callback::Bool=true)
+    if callback
+        for item in values(lru.ht)
+            lru.cb(item.k, item.v)
+        end
     end
     empty!(lru.ht)
     empty!(lru.q)

--- a/src/procglobal.jl
+++ b/src/procglobal.jl
@@ -1,0 +1,64 @@
+# process global blob collection.
+const MAXBLOBSZ = 128*1024*1024
+
+type ProcessGlobalBlob
+    maxcache::Int
+    storepath::AbstractString
+    coll::BlobCollection
+
+    function ProcessGlobalBlob(maxcache::Int, storepath::AbstractString=tempdir())
+        io = FileBlobIO(Any, true)
+        coll = BlobCollection(Any, Mutable(MAXBLOBSZ, io), io; maxcache=maxcache)
+        
+        new(maxcache, storepath, coll)
+    end
+end
+
+function append!{T}(gb::ProcessGlobalBlob, data::T)
+    meta = FileMeta("", 0, Base.summarysize(data))
+    coll = gb.coll
+    blob = append!(coll, T, meta, StrongLocality(myid()), Nullable(data))
+    meta.filename = joinpath(gb.storepath, string(blob.id))
+    @logmsg("keeping as blob $(meta.filename)")
+    #@logmsg(data)
+    (coll.id, blob.id)
+end
+
+load(gb::ProcessGlobalBlob, ids::Tuple) = load(ids...)
+flush(gb::ProcessGlobalBlob, ids::Tuple) = flush(ids...)
+#=
+type ProcessGlobalBlobs
+    maxcache::Int
+    storepath::AbstractString
+    collections::Dict{Type, BlobCollection}
+
+    function ProcessGlobalBlobs(maxcache::Int, storepath::AbstractString=tempdir())
+        new(maxcache, storepath, Dict{Type,BlobCollection}())
+    end
+end
+
+
+getcoll{T<:Any}(gb::ProcessGlobalBlobs, ::Type{T}) = _getcoll(gb, T)
+getcoll{T<:Array}(gb::ProcessGlobalBlobs, ::Type{T}) = getcoll(gb, T, eltype(T))
+getcoll{T<:Array,E<:Real}(gb::ProcessGlobalBlobs, ::Type{T}, ::Type{E}) = _getcoll(gb, Array{E})
+getcoll{T<:Array,E<:Any}(gb::ProcessGlobalBlobs, ::Type{T}, ::Type{E}) = _getcoll(gb, Any)
+
+function _getcoll{T}(gb::ProcessGlobalBlobs, ::Type{T})
+    allblobs = gb.collections
+    if !(T in keys(allblobs))
+        io = FileBlobIO(T, true)
+        allblobs[T] = BlobCollection(T, Mutable(MAXBLOBSZ, io), io; maxcache=2)
+    end
+    allblobs[T]
+end
+storepath(gb::ProcessGlobalBlobs, T::Type) = joinpath(gb.storepath, string(hash(T)))
+
+function append!{T}(gb::ProcessGlobalBlobs, data::T)
+    meta = FileMeta("", 0, sersz(data))
+    coll = getcoll(T)
+    blob = append!(coll, T, meta, StrongLocality(myid()), Nullable(data))
+    meta.filename = joinpath(storepath(T), string(blob.id))
+    @logmsg("keeping as blob $(meta.filename)")
+    (coll.id, blob.id)
+end
+=#


### PR DESCRIPTION
- Process global blob collection
  - easy integration
  - generic io methods to handle `Any` types
- FileBlobIO methods to handle multi dimensional dense arrays
- keep track of mmapped pointers and do `sync!` or `write` as appropriate
- can change cache size after creation
- added `flush` to remove selected blobs from cache
- minor fixes 
