### PR TITLE
multiple cache limiting strategies

### DIFF
--- a/src/Blobs.jl
+++ b/src/Blobs.jl
@@ -17,6 +17,7 @@ export BlobMeta, TypedMeta, FileMeta, FunctionMeta
 export BlobIO, NoopBlobIO, FileBlobIO, FunctionBlobIO
 export Blob, BlobCollection, blobids, load, save, serialize, deserialize, register, deregister, append!, flush, max_cached, max_cached!
 export ProcessGlobalBlob
+export maxmem, maxcount
 
 # enable logging only during debugging
 #using Logging

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -184,10 +184,11 @@ type BlobCollection{T, M<:Mutability}
     cache::LRU{UUID,T}
 end
 
-function BlobCollection{T,M<:Mutability}(::Type{T}, mutability::M, reader::BlobIO; maxcache::Int=10, nodemap::NodeMap=DEF_NODE_MAP, id::UUID=uuid4())
+function BlobCollection{T,M<:Mutability}(::Type{T}, mutability::M, reader::BlobIO; maxcache::Int=10, strategy::Function=maxcount, nodemap::NodeMap=DEF_NODE_MAP, id::UUID=uuid4())
     L = typeof(locality(reader))
     blobs = Dict{UUID,Blob{T,L}}()
-    cache = LRU{UUID,T}(maxcache)
+    @logmsg("creating blobcollection with $maxcache $strategy")
+    cache = LRU{UUID,T}(maxcache; strategy=strategy)
     coll = BlobCollection{T,M}(id, mutability, reader, nodemap, blobs, maxcache, cache)
     coll.cache.cb = (blobid,data)->save(coll, blobid)
     register(coll)

--- a/src/procglobal.jl
+++ b/src/procglobal.jl
@@ -3,14 +3,15 @@ const MAXBLOBSZ = 128*1024*1024
 
 type ProcessGlobalBlob
     maxcache::Int
+    strategy::Function
     storepath::AbstractString
     coll::BlobCollection
 
-    function ProcessGlobalBlob(maxcache::Int, storepath::AbstractString=tempdir())
+    function ProcessGlobalBlob(maxcache::Int, strategy::Function, storepath::AbstractString=tempdir())
         io = FileBlobIO(Any, true)
-        coll = BlobCollection(Any, Mutable(MAXBLOBSZ, io), io; maxcache=maxcache)
+        coll = BlobCollection(Any, Mutable(MAXBLOBSZ, io), io; maxcache=maxcache, strategy=strategy)
         
-        new(maxcache, storepath, coll)
+        new(maxcache, strategy, storepath, coll)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ include("test_attributes.jl")
 
 println("testing blobs...")
 include("test_blobs.jl")
+include("test_memlimit_blobs.jl")
 
 #if !isless(Base.VERSION, v"0.5.0-")
 #println("testing matrix blobs...")

--- a/test/test_memlimit_blobs.jl
+++ b/test/test_memlimit_blobs.jl
@@ -1,0 +1,16 @@
+using Blobs
+using Base.Test
+import Blobs: @logmsg
+
+const SZ_100MB = 100*1024*1024
+function test_memlimit()
+    PB = ProcessGlobalBlob(SZ_100MB, maxmem)
+    for idx in 1:12
+        A = Array(UInt8, 10*1024*1024)
+        append!(PB, A)
+        @test length(PB.coll.cache) <= 10
+        @test length(PB.coll.blobs) == idx
+    end
+end
+
+test_memlimit()


### PR DESCRIPTION
Cache limit can now be either plain item count or the memory footprint.
The type of limit can be specified (as a function) along with the limit value.
Two strategies are already supplied, `maxcount` and `maxmem`.

The `maxmem` strategy uses `Base.symmarysize` to estimate the memory footprint of cached items.
