### PR TITLE
avoid a remotecall_fetch

### DIFF
--- a/src/Blobs.jl
+++ b/src/Blobs.jl
@@ -20,6 +20,17 @@ export ProcessGlobalBlob
 export maxmem, maxcount
 
 # enable logging only during debugging
+if (Base.VERSION < v"0.5.0-")
+threadid() = 1
+else
+using Base.Threads
+end
+
+function tstr()
+    t = time()
+    string(Libc.strftime("%Y-%m-%dT%H:%M:%S",t), Libc.strftime("%z",t)[1:end-2], ":", Libc.strftime("%z",t)[end-1:end])
+end
+
 #using Logging
 #const logger = Logging.configure(level=DEBUG)
 ##const logger = Logging.configure(filename="/tmp/blobs$(getpid()).log", level=DEBUG)
@@ -32,7 +43,7 @@ macro logmsg(s)
 end
 #macro logmsg(s)
 #    quote
-#        info($(esc(s)))
+#        info(tstr(), " [", myid(), "-", threadid(), "] ", $(esc(s)))
 #    end
 #end
 

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -332,7 +332,7 @@ function load{T,L<:StrongLocality}(coll::BlobCollection, blob::Blob{T,L})
         if val == nothing
             # select a node from blob's local nodes
             fetchfrom = select_local(coll, blob)
-            val = remotecall_fetch(load_local, fetchfrom, coll.id, blob.id)
+            val = (fetchfrom == myid()) ? load_local(coll.id, blob.id) : remotecall_fetch(load_local, fetchfrom, coll.id, blob.id)
         end
         blob.data.value = coll.cache[blob.id] = val
     end


### PR DESCRIPTION
Avoid remotecall when we can.
Print time and thread id while logging (Logging.jl is broken).
