### PR TITLE
don't rely on weakref being null, fix blobcache

### DIFF
--- a/src/cache/blobcache.jl
+++ b/src/cache/blobcache.jl
@@ -93,7 +93,7 @@ function Base.setindex!{K, V}(lru::LRU{K, V}, v, key)
     end
 
     while lru.isfull(lru)
-        rm = pop!(lru.q)
+        rm = last(lru.q)
         delete!(lru, rm.k)
     end
 
@@ -104,7 +104,7 @@ function Base.resize!(lru::LRU, n::Int)
     n < 0 && error("size must be a positive integer")
     lru.maxsize = n
     while lru.isfull(lru)
-        rm = pop!(lru.q)
+        rm = last(lru.q)
         delete!(lru, rm.k)
     end
     return lru


### PR DESCRIPTION
- Checking weakref value to be null as an indicator of gc is not reliable. We probably need a finalizer for that, but all finalizers don't get called immediately at the moment (ref: https://github.com/JuliaLang/julia/pull/13995). Going without that optimization for now.
- fixed an issue where cache eviction was corrupting the cache
